### PR TITLE
Example code to get better type safety

### DIFF
--- a/samples/Paipurain.Samples.ConsoleApp/Program.cs
+++ b/samples/Paipurain.Samples.ConsoleApp/Program.cs
@@ -11,9 +11,9 @@ namespace Paipurain.Samples.ConsoleApp
         static async Task Main(string[] args)
         {
             var pipeline = new PipelineBuilder<string[], string>()
-                .AddBlock<string[], string>(GetFilePath)
-                .AddBlock<string, string>(ReadFileContent)
-                .AddBlock<string, string>(AttachText)
+                .AddBlock(GetFilePath)
+                .AddBlock(ReadFileContent)
+                .AddBlock(AttachText)
                 .Build();
 
             var value = await pipeline.Process(args);

--- a/src/Paipurain/Builder/AsyncPipelineBuilder.cs
+++ b/src/Paipurain/Builder/AsyncPipelineBuilder.cs
@@ -6,8 +6,8 @@ namespace Paipurain.Builder
 {
     public partial class PipelineBuilder<TInput, TOutput>
     {
-        public PipelineBuilder<TInput, TOutput> AddBlock<TTransformFunctionInput, TTransformFunctionOutput>(
-            Func<TTransformFunctionInput, Task<TTransformFunctionOutput>> asyncTransformFunction)
+        public IPipelineBuilder<TInput, TOutput, TTransformFunctionOutput> AddBlockAsync<TTransformFunctionOutput>(
+            Func<TInput, Task<TTransformFunctionOutput>> asyncTransformFunction)
         {
             if (asyncTransformFunction == null)
                 throw new ArgumentNullException();
@@ -15,7 +15,7 @@ namespace Paipurain.Builder
             LinkToPredecessorBlock(
                 CreateAsynchronousBlock(asyncTransformFunction));
 
-            return this;
+            return new IntermediatePipelineBuilder<TTransformFunctionOutput>(this);
         }
 
         private IDataflowBlock CreateAsynchronousBlock<TTransformFunctionInput, TTransformFunctionOutput>(

--- a/src/Paipurain/Builder/IPipelineBuilder.cs
+++ b/src/Paipurain/Builder/IPipelineBuilder.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Paipurain.Builder
+{
+    public interface IPipelineBuilder<TPipeInput, TPipeOutput, TInput>
+    {
+        // TPipeInput is the initial input to the entire pipeline, which we need for the .Build() method
+        // TPipeOutput is the final output of the entire pipeline, which we need for the .Build() method
+        // TInput is the input to this stage (output from the previous stage)
+        // TOutput is the output of each individual stage.
+
+        IPipelineBuilder<TPipeInput, TPipeOutput, TOutput> AddBlock<TOutput>(
+            Func<TInput, TOutput> transformFunction);
+
+        IPipelineBuilder<TPipeInput, TPipeOutput, TOutput> AddBlockAsync<TOutput>(
+            Func<TInput, Task<TOutput>> asyncTransformFunction);
+
+        IPipeline<TPipeInput, TPipeOutput> Build();
+    }
+}

--- a/src/Paipurain/Builder/PipelineBuilder.T2.cs
+++ b/src/Paipurain/Builder/PipelineBuilder.T2.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks.Dataflow;
 
 namespace Paipurain.Builder
 {
-    public partial class PipelineBuilder<TInput, TOutput>
+    public partial class PipelineBuilder<TInput, TOutput> : IPipelineBuilder<TInput, TOutput, TInput>
     {
         private IDataflowBlock _initialBlock;
         private IDataflowBlock _lastBlock;

--- a/src/Paipurain/Builder/SyncPipelineBuilder.cs
+++ b/src/Paipurain/Builder/SyncPipelineBuilder.cs
@@ -1,12 +1,13 @@
 ﻿using System;
+using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 
 namespace Paipurain.Builder
 {
     public partial class PipelineBuilder<TInput, TOutput>
     {
-        public PipelineBuilder<TInput, TOutput> AddBlock<TTransformFunctionInput, TTransformFunctionOutput>(
-            Func<TTransformFunctionInput, TTransformFunctionOutput> transformFunction)
+        public IPipelineBuilder<TInput, TOutput, TTransformFunctionOutput> AddBlock<TTransformFunctionOutput>(
+            Func<TInput, TTransformFunctionOutput> transformFunction)
         {
             if (transformFunction == null)
                 throw new ArgumentNullException();
@@ -14,7 +15,7 @@ namespace Paipurain.Builder
             LinkToPredecessorBlock(
                 CreateSynchronousBlock(transformFunction));
 
-            return this;
+            return new IntermediatePipelineBuilder<TTransformFunctionOutput>(this);
         }
 
         private IDataflowBlock CreateSynchronousBlock<TTransformFunctionInput, TTransformFunctionOutput>(
@@ -22,6 +23,44 @@ namespace Paipurain.Builder
         {
             return new TransformBlock<TransformWrapper<TOutput>, TransformWrapper<TOutput>>(
                 (unit) => new TransformWrapper<TOutput>(func(unit.Value), unit.Completion));
+        }
+
+        private class IntermediatePipelineBuilder<TIn> : IPipelineBuilder<TInput, TOutput, TIn>
+        {
+            private readonly PipelineBuilder<TInput, TOutput> _builder;
+
+            public IntermediatePipelineBuilder(PipelineBuilder<TInput, TOutput> builder)
+            {
+                _builder = builder;
+            }
+
+
+            public IPipelineBuilder<TInput, TOutput, TTransformFunctionOutput> AddBlock<TTransformFunctionOutput>(Func<TIn, TTransformFunctionOutput> transformFunction)
+            {
+                if (transformFunction == null)
+                    throw new ArgumentNullException();
+
+                _builder.LinkToPredecessorBlock(
+                    _builder.CreateSynchronousBlock(transformFunction));
+
+                return new IntermediatePipelineBuilder<TTransformFunctionOutput>(_builder);
+            }
+
+            public IPipelineBuilder<TInput, TOutput, TTransformFunctionOutput> AddBlockAsync<TTransformFunctionOutput>(Func<TIn, Task<TTransformFunctionOutput>> asyncTransformFunction)
+            {
+                if (asyncTransformFunction == null)
+                    throw new ArgumentNullException();
+
+                _builder.LinkToPredecessorBlock(
+                    _builder.CreateAsynchronousBlock(asyncTransformFunction));
+
+                return new IntermediatePipelineBuilder<TTransformFunctionOutput>(_builder);
+            }
+
+            public IPipeline<TInput, TOutput> Build()
+            {
+                return _builder.Build();
+            }
         }
     }
 }


### PR DESCRIPTION
See the commit message for more details about what changes, including positives and negatives.

This PR provides more type-safety through improved type inference, though some concessions are made:

1. The second .AddBlock variant had to be renamed to .AddBlockAsync, the compiler can't automatically select the correct overload anymore because of the aggressive type inferencing
2. The IPipelineBuilder interface has three generic type parameters, which is too many for some people's tastes
3. We create throwaway intermediate builder objects after each .AddBlock call, which may be a concern in some use-cases.

In exchange, we get a few benefits:

1. Most calls to .AddBlock and .AddBlockAsync don't require explicit type parameters
1. Non-reflection calls to .AddBlock and .AddBlockAsync will be type-safe on the input. That is, it's not possible to call .AddBlock with an input type which doesn't match the output of the previous .AddBlock call. (being type-safe on the .Build() method requires larger changes to PipelineBuilder which may or may not be desirable, but let me know if you want to see what that looks like)

This PR is provided just as an example of the approach. It's to the maintainers to decide whether this is desirable or not.